### PR TITLE
Do not attempt to load non-File instances via Bio-Formats

### DIFF
--- a/src/main/java/io/scif/bf/BioFormatsFormat.java
+++ b/src/main/java/io/scif/bf/BioFormatsFormat.java
@@ -43,6 +43,7 @@ import io.scif.io.RandomAccessInputStream;
 import io.scif.ome.services.OMEXMLService;
 import io.scif.util.FormatTools;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -312,7 +313,7 @@ public class BioFormatsFormat extends AbstractFormat {
 
 		@Override
 		public boolean isFormat(final String name, final SCIFIOConfig config) {
-			if (!realSource(name)) return false;
+			if (!new File(name).exists() || !realSource(name)) return false;
 			return createImageReader(this).isThisType(name, config.checkerIsOpen());
 		}
 


### PR DESCRIPTION
There is apparently code in Bio-Formats that can open random access
streams that are not backed by local files, but we do not use that
code path anyway (at least if this developer understood Curtis
Rueden's generous education correctly).

So let's not have tons of attempts by each Bio-Formats reader to
read something that we know it cannot read, at least the way we
asked them to read it.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
